### PR TITLE
Setup test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 
 coverage
+cov_profile
 
 .env
 

--- a/deno.json
+++ b/deno.json
@@ -2,6 +2,9 @@
   "version": "0.1.0",
   "tasks": {
     "test": "deno test -E -N",
+    "test:coverage": "deno task test --coverage=cov_profile", 
+    "coverage:print": "deno coverage cov_profile",
+    "coverage:html": "deno coverage cov_profile --html",
     "fmt": "deno fmt --ignore=\"coverage,demo\"",
     "lint": "deno lint src tests",
     "setup:meili": "deno --allow-net --allow-env scripts/setup_meilisearch.ts"

--- a/deno.json
+++ b/deno.json
@@ -3,8 +3,10 @@
   "tasks": {
     "test": "deno test -E -N",
     "test:coverage": "deno task test --coverage=cov_profile", 
-    "coverage:print": "deno coverage cov_profile",
+    "coverage:print": "deno coverage --exclude='utils' cov_profile",
     "coverage:html": "deno coverage cov_profile --html",
+    "coverage:ui": "deno --allow-net --allow-read scripts/serve_coverage.ts cov_profile/html",
+"coverage": "deno task test:coverage && deno task coverage:print && deno task coverage:html && echo 'To see coverage report in UI, run: deno task coverage:ui and open http://0.0.0.0:8000'",
     "fmt": "deno fmt --ignore=\"coverage,demo\"",
     "lint": "deno lint src tests",
     "setup:meili": "deno --allow-net --allow-env scripts/setup_meilisearch.ts"

--- a/deno.json
+++ b/deno.json
@@ -2,11 +2,11 @@
   "version": "0.1.0",
   "tasks": {
     "test": "deno test -E -N",
-    "test:coverage": "deno task test --coverage=cov_profile", 
+    "test:coverage": "deno task test --coverage=cov_profile",
     "coverage:print": "deno coverage --exclude='utils' cov_profile",
     "coverage:html": "deno coverage cov_profile --html",
     "coverage:ui": "deno --allow-net --allow-read scripts/serve_coverage.ts cov_profile/html",
-"coverage": "deno task test:coverage && deno task coverage:print && deno task coverage:html && echo 'To see coverage report in UI, run: deno task coverage:ui and open http://0.0.0.0:8000'",
+    "coverage": "deno task test:coverage && deno task coverage:print && deno task coverage:html && echo 'To see coverage report in UI, run: deno task coverage:ui and open http://0.0.0.0:8000'",
     "fmt": "deno fmt --ignore=\"coverage,demo\"",
     "lint": "deno lint src tests",
     "setup:meili": "deno --allow-net --allow-env scripts/setup_meilisearch.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -8,20 +8,27 @@
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@^1.0.6": "1.0.6",
     "jsr:@std/bytes@0.223": "0.223.0",
+    "jsr:@std/cli@^1.0.6": "1.0.6",
     "jsr:@std/data-structures@^1.0.4": "1.0.4",
+    "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.2",
+    "jsr:@std/fmt@^1.0.2": "1.0.2",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.4",
     "jsr:@std/fs@^1.0.4": "1.0.4",
     "jsr:@std/fs@~0.229.3": "0.229.3",
+    "jsr:@std/http@*": "1.0.8",
     "jsr:@std/internal@^1.0.4": "1.0.4",
     "jsr:@std/io@0.223": "0.223.0",
+    "jsr:@std/media-types@^1.0.3": "1.0.3",
+    "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1": "1.0.6",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@~0.225.2": "0.225.2",
+    "jsr:@std/streams@^1.0.7": "1.0.7",
     "jsr:@std/testing@^1.0.3": "1.0.3",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
@@ -66,8 +73,14 @@
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
+    "@std/cli@1.0.6": {
+      "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
+    },
     "@std/data-structures@1.0.4": {
       "integrity": "fa0e20c11eb9ba673417450915c750a0001405a784e2a4e0c3725031681684a0"
+    },
+    "@std/encoding@1.0.5": {
+      "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
     },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
@@ -90,6 +103,18 @@
         "jsr:@std/path@^1.0.6"
       ]
     },
+    "@std/http@1.0.8": {
+      "integrity": "6ea1b2e8d33929967754a3b6d6c6f399ad6647d7bbb5a466c1eaf9b294a6ebcd",
+      "dependencies": [
+        "jsr:@std/cli",
+        "jsr:@std/encoding",
+        "jsr:@std/fmt@^1.0.2",
+        "jsr:@std/media-types",
+        "jsr:@std/net",
+        "jsr:@std/path@^1.0.6",
+        "jsr:@std/streams"
+      ]
+    },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
     },
@@ -99,6 +124,12 @@
         "jsr:@std/assert@0.223",
         "jsr:@std/bytes"
       ]
+    },
+    "@std/media-types@1.0.3": {
+      "integrity": "b12d30a7852f7578f4d210622df713bbfd1cbdd9b4ec2eaf5c1845ab70bab159"
+    },
+    "@std/net@1.0.4": {
+      "integrity": "2f403b455ebbccf83d8a027d29c5a9e3a2452fea39bb2da7f2c04af09c8bc852"
     },
     "@std/path@0.223.0": {
       "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
@@ -117,6 +148,9 @@
     },
     "@std/path@1.0.6": {
       "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
+    },
+    "@std/streams@1.0.7": {
+      "integrity": "1a93917ca0c58c01b2bfb93647189229b1702677f169b6fb61ad6241cd2e499b"
     },
     "@std/testing@1.0.3": {
       "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",

--- a/deno.lock
+++ b/deno.lock
@@ -8,27 +8,20 @@
     "jsr:@std/assert@0.226": "0.226.0",
     "jsr:@std/assert@^1.0.6": "1.0.6",
     "jsr:@std/bytes@0.223": "0.223.0",
-    "jsr:@std/cli@^1.0.6": "1.0.6",
     "jsr:@std/data-structures@^1.0.4": "1.0.4",
-    "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@0.223": "0.223.0",
     "jsr:@std/fmt@1": "1.0.2",
-    "jsr:@std/fmt@^1.0.2": "1.0.2",
     "jsr:@std/fs@0.223": "0.223.0",
     "jsr:@std/fs@1": "1.0.4",
     "jsr:@std/fs@^1.0.4": "1.0.4",
     "jsr:@std/fs@~0.229.3": "0.229.3",
-    "jsr:@std/http@*": "1.0.8",
     "jsr:@std/internal@^1.0.4": "1.0.4",
     "jsr:@std/io@0.223": "0.223.0",
-    "jsr:@std/media-types@^1.0.3": "1.0.3",
-    "jsr:@std/net@^1.0.4": "1.0.4",
     "jsr:@std/path@0.223": "0.223.0",
     "jsr:@std/path@1": "1.0.6",
     "jsr:@std/path@1.0.0-rc.1": "1.0.0-rc.1",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@~0.225.2": "0.225.2",
-    "jsr:@std/streams@^1.0.7": "1.0.7",
     "jsr:@std/testing@^1.0.3": "1.0.3",
     "jsr:@ts-morph/bootstrap@0.24": "0.24.0",
     "jsr:@ts-morph/common@0.24": "0.24.0",
@@ -73,14 +66,8 @@
     "@std/bytes@0.223.0": {
       "integrity": "84b75052cd8680942c397c2631318772b295019098f40aac5c36cead4cba51a8"
     },
-    "@std/cli@1.0.6": {
-      "integrity": "d22d8b38c66c666d7ad1f2a66c5b122da1704f985d3c47f01129f05abb6c5d3d"
-    },
     "@std/data-structures@1.0.4": {
       "integrity": "fa0e20c11eb9ba673417450915c750a0001405a784e2a4e0c3725031681684a0"
-    },
-    "@std/encoding@1.0.5": {
-      "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
     },
     "@std/fmt@0.223.0": {
       "integrity": "6deb37794127dfc7d7bded2586b9fc6f5d50e62a8134846608baf71ffc1a5208"
@@ -103,18 +90,6 @@
         "jsr:@std/path@^1.0.6"
       ]
     },
-    "@std/http@1.0.8": {
-      "integrity": "6ea1b2e8d33929967754a3b6d6c6f399ad6647d7bbb5a466c1eaf9b294a6ebcd",
-      "dependencies": [
-        "jsr:@std/cli",
-        "jsr:@std/encoding",
-        "jsr:@std/fmt@^1.0.2",
-        "jsr:@std/media-types",
-        "jsr:@std/net",
-        "jsr:@std/path@^1.0.6",
-        "jsr:@std/streams"
-      ]
-    },
     "@std/internal@1.0.4": {
       "integrity": "62e8e4911527e5e4f307741a795c0b0a9e6958d0b3790716ae71ce085f755422"
     },
@@ -124,12 +99,6 @@
         "jsr:@std/assert@0.223",
         "jsr:@std/bytes"
       ]
-    },
-    "@std/media-types@1.0.3": {
-      "integrity": "b12d30a7852f7578f4d210622df713bbfd1cbdd9b4ec2eaf5c1845ab70bab159"
-    },
-    "@std/net@1.0.4": {
-      "integrity": "2f403b455ebbccf83d8a027d29c5a9e3a2452fea39bb2da7f2c04af09c8bc852"
     },
     "@std/path@0.223.0": {
       "integrity": "593963402d7e6597f5a6e620931661053572c982fc014000459edc1f93cc3989",
@@ -148,9 +117,6 @@
     },
     "@std/path@1.0.6": {
       "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
-    },
-    "@std/streams@1.0.7": {
-      "integrity": "1a93917ca0c58c01b2bfb93647189229b1702677f169b6fb61ad6241cd2e499b"
     },
     "@std/testing@1.0.3": {
       "integrity": "f98c2bee53860a5916727d7e7d3abe920dd6f9edace022e2d059f00d05c2cf42",

--- a/scripts/serve_coverage.ts
+++ b/scripts/serve_coverage.ts
@@ -1,0 +1,17 @@
+const coverageDir = Deno.args[0];
+
+if (!coverageDir) {
+  throw new Error("No coverage directory provided");
+}
+
+Deno.serve((req: Request): Response => {
+  const pathname = new URL(req.url).pathname;
+  const headers = { "Content-Type": "text/html" };
+  const filePath = `${coverageDir}${
+    pathname === "/" ? "/index.html" : pathname
+  }`;
+
+  return new Response(Deno.readTextFileSync(filePath), {
+    headers,
+  });
+});


### PR DESCRIPTION
Resolves #7 

Created a couple scripts for generating coverage and displaying them.
The base command is: 
```bash
deno task coverage
```
This will  run all the tests, create the coverage report in the _cov_profile_ folder, print it to the terminal and create html versions of these reports as well.
Also added a small server script in the _utils_ folder for viewing the html files.
Run it by using the following command:
```bash
deno task coverage:ui
```
I suggest trying it out locally to see how it works, and feel free to add any improvements to the flow.